### PR TITLE
Add libdmapsharing and depends (libgee, avahi, dbus-python) for DAAP support

### DIFF
--- a/disable-daap-preferences.patch
+++ b/disable-daap-preferences.patch
@@ -1,0 +1,14 @@
+--- rhythmbox-3.4.2/plugins/daap/rb-daap-plugin.c.orig	2017-10-08 03:07:13.000000000 +0100
++++ rhythmbox-3.4.2/plugins/daap/rb-daap-plugin.c	2018-02-09 01:32:56.397621163 +0000
+@@ -139,9 +139,7 @@
+ 
+ RB_DEFINE_PLUGIN(RB_TYPE_DAAP_PLUGIN,
+ 		 RBDaapPlugin,
+-		 rb_daap_plugin,
+-		 (G_IMPLEMENT_INTERFACE_DYNAMIC (PEAS_GTK_TYPE_CONFIGURABLE,
+-						peas_gtk_configurable_iface_init)))
++		 rb_daap_plugin,)
+ 
+ static void
+ rb_daap_plugin_init (RBDaapPlugin *plugin)
+

--- a/disable-daap-preferences.patch
+++ b/disable-daap-preferences.patch
@@ -1,6 +1,21 @@
---- rhythmbox-3.4.2/plugins/daap/rb-daap-plugin.c.orig	2017-10-08 03:07:13.000000000 +0100
-+++ rhythmbox-3.4.2/plugins/daap/rb-daap-plugin.c	2018-02-09 01:32:56.397621163 +0000
-@@ -139,9 +139,7 @@
+From 0972973bba482d0013221981d1c945f2886b3d00 Mon Sep 17 00:00:00 2001
+From: Andrew Hayzen <ahayzen@gmail.com>
+Date: Fri, 9 Feb 2018 02:06:56 +0000
+Subject: [PATCH] Patch to disable DAAP preferences, to prevent attempting to
+ broadcast or search
+
+Broadcasting and search don't work as they require a running MDNS service.
+For now we patch out the preferences menu, the user can still connect to a DAAP
+share from the menu in the toolbar.
+---
+ plugins/daap/rb-daap-plugin.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/plugins/daap/rb-daap-plugin.c b/plugins/daap/rb-daap-plugin.c
+index 5e5af17e8..5aa320a97 100644
+--- a/plugins/daap/rb-daap-plugin.c
++++ b/plugins/daap/rb-daap-plugin.c
+@@ -139,9 +139,7 @@ static void peas_gtk_configurable_iface_init (PeasGtkConfigurableInterface *ifac
  
  RB_DEFINE_PLUGIN(RB_TYPE_DAAP_PLUGIN,
  		 RBDaapPlugin,
@@ -11,4 +26,6 @@
  
  static void
  rb_daap_plugin_init (RBDaapPlugin *plugin)
+-- 
+2.14.1
 

--- a/org.gnome.Rhythmbox3.json
+++ b/org.gnome.Rhythmbox3.json
@@ -146,6 +146,11 @@
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/rhythmbox/3.4/rhythmbox-3.4.2.tar.xz",
                     "sha256": "c27622fb7658d3c8e935937a562ebd8a65f5316a12694d6a06cb17f790b6ec43"
+                },
+                /* Disable DAAP preferences as only connecting not broadcasting or searching works as they need MDNS service */
+                {
+                    "type": "patch",
+                    "path": "disable-daap-preferences.patch"
                 }
             ]
         }

--- a/org.gnome.Rhythmbox3.json
+++ b/org.gnome.Rhythmbox3.json
@@ -100,7 +100,7 @@
         /* libdmapsharing needs avahi or howl or libdns_sd */
         {
             "name": "avahi",
-            "config-opts": [ "--enable-compat-libdns_sd", "--with-distro=none", "--disable-gtk", "--disable-gtk3", "--disable-libdaemon", "--disable-manpages", "--disable-mono", "--disable-monodoc", "--disable-qt3", "--disable-qt4"  ],
+            "config-opts": [ "--with-distro=none", "--disable-gtk", "--disable-gtk3", "--disable-libdaemon", "--disable-manpages", "--disable-mono", "--disable-qt3", "--disable-qt4"  ],
             "sources": [
                 {
                     "type": "archive",
@@ -111,21 +111,21 @@
         },
         /* libdmapsharing needs gee-0.8 */
         {
-		    "name": "libgee",
-		    "build-options" : {
-		        "env": {
-		            "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR": "/app/share/gir-1.0",
-		            "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR": "/app/lib/girepository-1.0"
-		        }
-		    },
-		    "sources": [
-		        {
-		            "type": "archive",
-		            "url": "https://download.gnome.org/sources/libgee/0.20/libgee-0.20.0.tar.xz",
-		            "sha256": "21308ba3ed77646dda2e724c0e8d5a2f8d101fb05e078975a532d7887223c2bb"
-		        }
-		    ]
-		},
+	    "name": "libgee",
+	    "build-options" : {
+	        "env": {
+	            "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR": "/app/share/gir-1.0",
+	            "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR": "/app/lib/girepository-1.0"
+	        }
+	    },
+	    "sources": [
+	        {
+	            "type": "archive",
+	            "url": "https://download.gnome.org/sources/libgee/0.20/libgee-0.20.0.tar.xz",
+	            "sha256": "21308ba3ed77646dda2e724c0e8d5a2f8d101fb05e078975a532d7887223c2bb"
+	        }
+	    ]
+	},
         /* for DAAP support */
         {
             "name": "libdmapsharing",

--- a/org.gnome.Rhythmbox3.json
+++ b/org.gnome.Rhythmbox3.json
@@ -95,9 +95,10 @@
                     "url": "https://pypi.python.org/packages/ad/1b/76adc363212c642cabbf9329457a918308c0b9b5d38ce04d541a67255174/dbus-python-1.2.4.tar.gz#md5=7372a588c83a7232b4e08159bfd48fe5",
                     "sha256": "e2f1d6871f74fba23652e51d10873e54f71adab0525833c19bad9e99b1b2f9cc"
                 }
-            ]
+            ],
+            "cleanup": ["/lib", "/share/doc"]
         },
-        /* libdmapsharing needs avahi or howl or libdns_sd */
+        /* libdmapsharing needs development headers of avahi or howl or libdns_sd */
         {
             "name": "avahi",
             "config-opts": [ "--with-distro=none", "--disable-gtk", "--disable-gtk3", "--disable-libdaemon", "--disable-manpages", "--disable-mono", "--disable-qt3", "--disable-qt4"  ],
@@ -107,7 +108,8 @@
                     "url": "https://github.com/lathiat/avahi/archive/v0.7.tar.gz",
                     "sha256": "fd45480cef0559b3eab965ea3ad4fe2d7a8f27db32c851a032ee0b487c378329"
                 }
-            ]
+            ],
+            "cleanup": ["/bin"]
         },
         /* libdmapsharing needs gee-0.8 */
         {
@@ -126,7 +128,7 @@
 	        }
 	    ]
 	},
-        /* for DAAP support */
+        /* libdmapsharing is required for DAAP support */
         {
             "name": "libdmapsharing",
             "sources": [

--- a/org.gnome.Rhythmbox3.json
+++ b/org.gnome.Rhythmbox3.json
@@ -96,7 +96,7 @@
                     "sha256": "e2f1d6871f74fba23652e51d10873e54f71adab0525833c19bad9e99b1b2f9cc"
                 }
             ],
-            "cleanup": ["/lib", "/share/doc"]
+            "cleanup": [ "*" ]
         },
         /* libdmapsharing needs development headers of avahi or howl or libdns_sd */
         {
@@ -109,7 +109,7 @@
                     "sha256": "fd45480cef0559b3eab965ea3ad4fe2d7a8f27db32c851a032ee0b487c378329"
                 }
             ],
-            "cleanup": ["/bin"]
+            "cleanup": [ "/bin" ]
         },
         /* libdmapsharing needs gee-0.8 */
         {

--- a/org.gnome.Rhythmbox3.json
+++ b/org.gnome.Rhythmbox3.json
@@ -86,6 +86,57 @@
             ],
             "cleanup": [ "/include" ]
         },
+        /* avahi needs dbus-python */
+        {
+            "name": "dbus-python",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/ad/1b/76adc363212c642cabbf9329457a918308c0b9b5d38ce04d541a67255174/dbus-python-1.2.4.tar.gz#md5=7372a588c83a7232b4e08159bfd48fe5",
+                    "sha256": "e2f1d6871f74fba23652e51d10873e54f71adab0525833c19bad9e99b1b2f9cc"
+                }
+            ]
+        },
+        /* libdmapsharing needs avahi or howl or libdns_sd */
+        {
+            "name": "avahi",
+            "config-opts": [ "--enable-compat-libdns_sd", "--with-distro=none", "--disable-gtk", "--disable-gtk3", "--disable-libdaemon", "--disable-manpages", "--disable-mono", "--disable-monodoc", "--disable-qt3", "--disable-qt4"  ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/lathiat/avahi/archive/v0.7.tar.gz",
+                    "sha256": "fd45480cef0559b3eab965ea3ad4fe2d7a8f27db32c851a032ee0b487c378329"
+                }
+            ]
+        },
+        /* libdmapsharing needs gee-0.8 */
+        {
+		    "name": "libgee",
+		    "build-options" : {
+		        "env": {
+		            "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR": "/app/share/gir-1.0",
+		            "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR": "/app/lib/girepository-1.0"
+		        }
+		    },
+		    "sources": [
+		        {
+		            "type": "archive",
+		            "url": "https://download.gnome.org/sources/libgee/0.20/libgee-0.20.0.tar.xz",
+		            "sha256": "21308ba3ed77646dda2e724c0e8d5a2f8d101fb05e078975a532d7887223c2bb"
+		        }
+		    ]
+		},
+        /* for DAAP support */
+        {
+            "name": "libdmapsharing",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/GNOME/libdmapsharing/archive/LIBDMAPSHARING_2_9_39.tar.gz",
+                    "sha256": "0a94bdcd3c991145986fa0b18b802cf3a677db1eafa9e81ddc4f64c21a4c4a3b"
+                }
+            ]
+        },
         {
             "name": "rhythmbox",
             "sources": [


### PR DESCRIPTION
This allows for the daap plugin to compile when building rhythmbox. DAAP (https://en.wikipedia.org/wiki/Digital_Audio_Access_Protocol) is commonly used for sharing iTunes libraries across a local network, or NAS/Media drives such as Synology drives can be setup to use it. So it is useful to have :-) 

I found that the daap plugin was failing due to `libdmapsharing` not existing.

libdmapsharing then depended on libgee, and required either avahi, howl or libdns_sd development headers. I went with avahi, this then required dbus-python.

Please check what I've done, I wonder if some of the config-opts can be reduced in avahi now I have got it working, I'll see if i can remove any of them.