### PR TITLE
Work-around mount point differences since gvfs access

### DIFF
--- a/org.gnome.Rhythmbox3.json
+++ b/org.gnome.Rhythmbox3.json
@@ -37,7 +37,9 @@
         /* DAAP broadcast and discovery */
         "--system-talk-name=org.freedesktop.Avahi",
         /* totem-pl-parser http support, for podcasts and streaming */
-        "--talk-name=org.gtk.vfs", "--talk-name=org.gtk.vfs.*"
+        "--talk-name=org.gtk.vfs", "--talk-name=org.gtk.vfs.*",
+        /* See #16 */
+        "--env=GIO_USE_VOLUME_MONITOR=unix"
     ],
     "build-options" : {
         "cflags": "-O2 -g",


### PR DESCRIPTION
Since we added gvfs access, ~/Music is not a separate mountpoint
anymore, from gio's point of view.

As rhythmdb expects mount points not to change, and ~/Music isn't
mountable anymore, then rhythmbox will hide it.

[perform_next_mount] rhythmdb.c:917: mounting file:///home/hadess/Music
[perform_next_mount_cb] rhythmdb.c:891: Unable to mount file:///home/hadess/Music: volume doesn’t implement mount
[perform_next_mount] rhythmdb.c:908: finished mounting

Closes: #16