### PR TITLE
Update gnome runtime to 3.36

### DIFF
--- a/org.gnome.Rhythmbox3.json
+++ b/org.gnome.Rhythmbox3.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Rhythmbox3",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.34",
+    "runtime-version": "3.36",
     "default-branch": "stable",
     "sdk": "org.gnome.Sdk",
     "command": "rhythmbox",


### PR DESCRIPTION
* Use --socket=fallback-x11
* No need to have a default branch
* Update shared-modules