### PR TITLE
Revert "Remove host DConf access"

### DIFF
--- a/org.gnome.Rhythmbox3.json
+++ b/org.gnome.Rhythmbox3.json
@@ -22,9 +22,9 @@
         "--socket=pulseaudio",
         /* Browse user's Music directory */
         "--filesystem=xdg-music",
-        /* Migrate DConf settings from the host */
-        "--metadata=X-DConf=migrate-path=/org/gnome/rhythmbox/",
-        "--require-version=1.8.0",
+        /* Needed for dconf to work */
+        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
         /* MPRIS */
         "--own-name=org.mpris.MediaPlayer2.rhythmbox",
         /* dbus media server */


### PR DESCRIPTION
This reverts commit 550a235d41fb7e3baba8c60ea82d44b8b5103fe5.

Flatpak 1.8.0 isn't widely available yet.

Closes: #35