### PR TITLE
Reinstate X-Flatpak-RenamedFrom.

### DIFF
--- a/org.gnome.Rhythmbox3.json
+++ b/org.gnome.Rhythmbox3.json
@@ -135,6 +135,9 @@
         {
             "name": "rhythmbox",
             "config-opts": [ "--disable-more-warnings" ],
+            "post-install": [
+                "desktop-file-edit --set-key=X-Flatpak-RenamedFrom --set-value='rhythmbox.desktop;' /app/share/applications/org.gnome.Rhythmbox3.desktop"
+            ],
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
This key used to be added by the Flatpak using the `rename-desktop-file` manifest option, but it got dropped on commit 08c5ac609b when the application ID changed.

This option allows apps to match the old version and new one, for example on Endless this is used to allow moving core OS apps to their flatpak versions without extra work, and configurations such as icon positions in the grid remain valid after upgrades without any extra input.