### PR TITLE
Update runtime to 40

### DIFF
--- a/org.gnome.Rhythmbox3.json
+++ b/org.gnome.Rhythmbox3.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Rhythmbox3",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.38",
+    "runtime-version": "40",
     "sdk": "org.gnome.Sdk",
     "command": "rhythmbox",
     "tags": [],


### PR DESCRIPTION
The GNOME 3.38 runtime is no longer supported as of August 19, 2021.

Maybe there is more change to be made.

++
