### PR TITLE
Work-around GStreamer libsoup plugin bug

### DIFF
--- a/org.gnome.Rhythmbox3.json
+++ b/org.gnome.Rhythmbox3.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Rhythmbox3",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "42",
+    "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
     "command": "rhythmbox",
     "tags": [],


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/gnome-build-meta/-/issues/498

Closes: #54