### PR TITLE
Remove the use of Notification hole

### DIFF
--- a/0001-notification-Fix-libnotify-warning-in-Flatpak.patch
+++ b/0001-notification-Fix-libnotify-warning-in-Flatpak.patch
@@ -1,0 +1,58 @@
+From 14e50fbbf6a83daa0f78844914b684ad29f9ecd6 Mon Sep 17 00:00:00 2001
+From: Bastien Nocera <hadess@hadess.net>
+Date: Wed, 31 Jan 2024 15:49:00 +0100
+Subject: [PATCH] notification: Fix libnotify warning in Flatpak
+
+When blocking direct access to the notification service, and relying on
+libnotify 0.8's implicit portal support, we got those warnings:
+
+(rhythmbox:2): libnotify-WARNING **: 15:02:43.424: Running in confined mode, using Portal notifications. Some features and hints won't be supported
+libnotify-Message: 15:02:43.424: Category is not available when using Portal Notifications
+libnotify-Message: 15:02:43.425: Category is not available when using Portal Notifications
+libnotify-Message: 15:02:43.454: Category is not available when using Portal Notifications
+
+We should only set the category when not using Flatpak.
+
+See https://github.com/flathub/org.gnome.Rhythmbox3/pull/65
+---
+ plugins/notification/rb-notification-plugin.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/plugins/notification/rb-notification-plugin.c b/plugins/notification/rb-notification-plugin.c
+index 40c62a8ac827..f2bc3ce513a7 100644
+--- a/plugins/notification/rb-notification-plugin.c
++++ b/plugins/notification/rb-notification-plugin.c
+@@ -59,6 +59,7 @@ struct _RBNotificationPlugin
+ 
+ 	gchar *notify_art_path;
+ 	RBExtDBKey *notify_art_key;
++	gboolean is_flatpak;
+ 	NotifyNotification *notification;
+ 	NotifyNotification *misc_notification;
+ 	gboolean notify_supports_actions;
+@@ -199,7 +200,7 @@ do_notify (RBNotificationPlugin *plugin,
+ 					      g_variant_new_string (image_uri));
+ 	}
+ 
+-        if (playback)
++        if (!plugin->is_flatpak && playback)
+         	notify_notification_set_category (notification, "x-gnome.music");
+         notify_notification_set_hint (notification, "desktop-entry",
+                                       g_variant_new_string ("org.gnome.Rhythmbox3"));
+@@ -649,8 +650,12 @@ impl_deactivate	(PeasActivatable *bplugin)
+ }
+ 
+ static void
+-rb_notification_plugin_init (RBNotificationPlugin *plugin)
++rb_notification_plugin_init (RBNotificationPlugin *bplugin)
+ {
++	RBNotificationPlugin *plugin;
++
++	plugin = RB_NOTIFICATION_PLUGIN (bplugin);
++	plugin->is_flatpak = g_file_test ("/.flatpak-info", G_FILE_TEST_EXISTS);
+ }
+ 
+ G_MODULE_EXPORT void
+-- 
+2.43.0
+

--- a/appdata-fixes.patch
+++ b/appdata-fixes.patch
@@ -1,0 +1,81 @@
+From ae8a49ecc266430869f5ceff1200d5f3580d44e2 Mon Sep 17 00:00:00 2001
+From: Bastien Nocera <hadess@hadess.net>
+Date: Wed, 31 Jan 2024 16:07:34 +0100
+Subject: [PATCH 1/4] data: Fix long summary after Flathub review
+
+Rephrase app summary so that Flathub does not consider it to be too
+long:
+https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/quality-guidelines/#not-too-long-1
+---
+ data/org.gnome.Rhythmbox3.appdata.xml.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/org.gnome.Rhythmbox3.appdata.xml.in b/data/org.gnome.Rhythmbox3.appdata.xml.in
+index 02bb503aa820..abc33d272928 100644
+--- a/data/org.gnome.Rhythmbox3.appdata.xml.in
++++ b/data/org.gnome.Rhythmbox3.appdata.xml.in
+@@ -6,7 +6,7 @@
+   <metadata_license>CC0-1.0</metadata_license>
+   <project_license>GPL-2.0+ and GFDL-1.3</project_license>
+   <name>Rhythmbox</name>
+-  <summary>Play and organize your music collection</summary>
++  <summary>Play and organize all your music</summary>
+   <description>
+     <p>
+       Rhythmbox is a music management application, designed to work well under the GNOME
+-- 
+2.43.0
+
+
+From bd942b695b5c3582effb40a11fe7d345ed5f79a7 Mon Sep 17 00:00:00 2001
+From: Bastien Nocera <hadess@hadess.net>
+Date: Wed, 31 Jan 2024 21:39:57 +0100
+Subject: [PATCH 3/4] data: Fix "appstream-missing-developer-name" linter error
+
+See https://docs.flathub.org/docs/for-app-authors/linter/#appstream-missing-developer-name
+---
+ data/org.gnome.Rhythmbox3.appdata.xml.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/data/org.gnome.Rhythmbox3.appdata.xml.in b/data/org.gnome.Rhythmbox3.appdata.xml.in
+index abc33d272928..8aba484f3637 100644
+--- a/data/org.gnome.Rhythmbox3.appdata.xml.in
++++ b/data/org.gnome.Rhythmbox3.appdata.xml.in
+@@ -7,6 +7,7 @@
+   <project_license>GPL-2.0+ and GFDL-1.3</project_license>
+   <name>Rhythmbox</name>
+   <summary>Play and organize all your music</summary>
++  <developer_name>The Rhythmbox developers</developer_name>
+   <description>
+     <p>
+       Rhythmbox is a music management application, designed to work well under the GNOME
+-- 
+2.43.0
+
+
+From 0502dbe2f9b1d8a28e5f483283be963be614f188 Mon Sep 17 00:00:00 2001
+From: Bastien Nocera <hadess@hadess.net>
+Date: Wed, 31 Jan 2024 21:41:12 +0100
+Subject: [PATCH 4/4] data: Fix "appstream-screenshot-missing-caption" linter
+ error
+
+See https://docs.flathub.org/docs/for-app-authors/linter/#appstream-screenshot-missing-caption
+---
+ data/org.gnome.Rhythmbox3.appdata.xml.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/data/org.gnome.Rhythmbox3.appdata.xml.in b/data/org.gnome.Rhythmbox3.appdata.xml.in
+index 8aba484f3637..b247924985b9 100644
+--- a/data/org.gnome.Rhythmbox3.appdata.xml.in
++++ b/data/org.gnome.Rhythmbox3.appdata.xml.in
+@@ -27,6 +27,7 @@
+   <screenshots>
+     <screenshot type="default">
+       <image>https://gitlab.gnome.org/GNOME/rhythmbox/-/raw/master/data/screenshots/rhythmbox-main-window.png?inline=false</image>
++      <caption>Main Window</caption>
+     </screenshot>
+   </screenshots>
+   <update_contact>jmatthew@gnome.org</update_contact>
+-- 
+2.43.0
+

--- a/org.gnome.Rhythmbox3.json
+++ b/org.gnome.Rhythmbox3.json
@@ -223,6 +223,10 @@
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/rhythmbox.git",
                     "commit": "1b4df30fcd66d2e9ff5a934f1ca3bfcbf3402847"
+                },
+                {
+                    "type": "patch",
+                    "path": "0001-notification-Fix-libnotify-warning-in-Flatpak.patch"
                 }
             ]
         }

--- a/org.gnome.Rhythmbox3.json
+++ b/org.gnome.Rhythmbox3.json
@@ -24,8 +24,6 @@
         "--own-name=org.mpris.MediaPlayer2.rhythmbox",
         /* media keys */
         "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
-        /* libnotify */
-        "--talk-name=org.freedesktop.Notifications",
         /* DAAP broadcast and discovery */
         "--system-talk-name=org.freedesktop.Avahi",
         /* totem-pl-parser http support, for podcasts and streaming */

--- a/org.gnome.Rhythmbox3.json
+++ b/org.gnome.Rhythmbox3.json
@@ -225,7 +225,12 @@
                 {
                     "type": "patch",
                     "path": "0001-notification-Fix-libnotify-warning-in-Flatpak.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "appdata-fixes.patch"
                 }
+
             ]
         }
     ]


### PR DESCRIPTION
Starting with libnotify 0.8, all calls go through the portal.