### PR TITLE
Remove gnome-settings-daemon MediaKeys access

### DIFF
--- a/org.gnome.Rhythmbox3.json
+++ b/org.gnome.Rhythmbox3.json
@@ -22,8 +22,6 @@
         "--require-version=1.8.0",
         /* MPRIS */
         "--own-name=org.mpris.MediaPlayer2.rhythmbox",
-        /* media keys */
-        "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
         /* DAAP broadcast and discovery */
         "--system-talk-name=org.freedesktop.Avahi",
         /* totem-pl-parser http support, for podcasts and streaming */


### PR DESCRIPTION
This was removed upstream, see:
https://gitlab.gnome.org/GNOME/rhythmbox/-/merge_requests/132